### PR TITLE
Feature add transport control pipe

### DIFF
--- a/dev/ivshmem/include/ivshmem-endpoint.h
+++ b/dev/ivshmem/include/ivshmem-endpoint.h
@@ -145,7 +145,6 @@ static inline int ivshm_ep_buf_add(struct ivshm_ep_buf *buf, void *base, size_t 
 #define IVSHM_EP_ID_EVENT_MANAGER       0x205
 
 /* Customer endpoints - Starting from 0x400 */
-#define IVSHM_EP_ID_SERIAL              0x400
 
 /* Endpoint usefull macros */
 #define EP_ID_MASK                      0xFFFF

--- a/dev/ivshmem/include/ivshmem-endpoint.h
+++ b/dev/ivshmem/include/ivshmem-endpoint.h
@@ -145,6 +145,7 @@ static inline int ivshm_ep_buf_add(struct ivshm_ep_buf *buf, void *base, size_t 
 #define IVSHM_EP_ID_EVENT_MANAGER       0x205
 
 /* Customer endpoints - Starting from 0x400 */
+#define IVSHM_EP_ID_SERIAL              0x400
 
 /* Endpoint usefull macros */
 #define EP_ID_MASK                      0xFFFF

--- a/dev/ivshmem/ivshmem-services.c
+++ b/dev/ivshmem/ivshmem-services.c
@@ -38,6 +38,10 @@
 #include "ivshmem-rpc.h"
 #endif /* WITH_DEV_IVSHMEM_SERVICES_RPC */
 
+#if defined WITH_DEV_IVSHMEM_SERVICES_SERIAL
+#include "ivshmem-serial.h"
+#endif
+
 #include "ivshmem-services.h"
 
 
@@ -54,6 +58,9 @@ static struct s_ivshm_services {
 #endif
 #if defined WITH_DEV_IVSHMEM_SERVICES_RPC
     { .init = ivshm_init_rpc, .remove = ivshm_exit_rpc, .name = "rpc"},
+#endif
+#if defined WITH_DEV_IVSHMEM_SERVICES_SERIAL
+    { .init = ivshm_init_serial, .remove = ivshm_exit_serial, .name = "serial" },
 #endif
 };
 

--- a/dev/ivshmem/ivshmem-services.c
+++ b/dev/ivshmem/ivshmem-services.c
@@ -87,7 +87,7 @@ int ivshm_init_services(struct ivshm_info *info)
 
         if (ret)
             printlk(LK_ERR, "%s:%d: Error during initialization of ivshm service %s\n",
-                __PRETTY_FUNCTION__, __LINE__, ivshm_services[i].name);
+                    __PRETTY_FUNCTION__, __LINE__, ivshm_services[i].name);
         else
             ivshm_services_mask |= (1ULL << i);
 unlock:

--- a/dev/ivshmem/services/rpc/ivshmem-rpc.c
+++ b/dev/ivshmem/services/rpc/ivshmem-rpc.c
@@ -76,7 +76,7 @@ struct ivshm_rpc_service *ivshm_get_rpc_service(unsigned id)
 }
 
 int ivshm_rpc_call(struct ivshm_rpc_service *service, unsigned rpc_id,
-                       void *in, size_t len, void *out, size_t *out_len)
+                   void *in, size_t len, void *out, size_t *out_len)
 {
     struct ivshm_ep_buf ep_buf;
     struct ivshm_rpc_header *hdr_out, hdr_in = {
@@ -243,7 +243,7 @@ void *ivshm_rpc_get_data(struct ivshm_rpc_service *service)
 }
 
 static status_t ivshm_rpc_send(struct ivshm_rpc_service *service,
-            unsigned rpc_id, void *in, size_t len, void *out, size_t *out_len)
+                               unsigned rpc_id, void *in, size_t len, void *out, size_t *out_len)
 {
     int ret;
 
@@ -265,7 +265,7 @@ static status_t ivshm_rpc_send(struct ivshm_rpc_service *service,
 }
 
 status_t ivshm_rpc_cmd(struct ivshm_rpc_service *service,
-            unsigned rpc_id)
+                       unsigned rpc_id)
 {
     status_t ret;
     int retcode;
@@ -291,7 +291,7 @@ error:
 }
 
 status_t ivshm_rpc_cmd_get(struct ivshm_rpc_service *service,
-                                        unsigned rpc_id, void *in, size_t sz)
+                           unsigned rpc_id, void *in, size_t sz)
 {
     status_t ret;
     size_t response_sz = sz;
@@ -309,7 +309,7 @@ error:
 }
 
 status_t ivshm_rpc_cmd_set(struct ivshm_rpc_service *service,
-                                        unsigned rpc_id, void *in, size_t sz)
+                           unsigned rpc_id, void *in, size_t sz)
 {
     status_t ret;
     unsigned retcode = 0;
@@ -351,7 +351,8 @@ static ssize_t ivshm_rpc_consume(struct ivshm_endpoint *ep,
     if (hdr->type == IVSHM_RPC_REPLY) {
         /* wake up client thread */
         event_signal(&service->wait, false);
-    } else if (hdr->type == IVSHM_RPC_CALL) {
+    }
+    else if (hdr->type == IVSHM_RPC_CALL) {
         /* Look for callback and jump in */
         int i = 0;
         struct rpc_client_callback *rpc_callback;
@@ -372,7 +373,8 @@ static ssize_t ivshm_rpc_consume(struct ivshm_endpoint *ep,
         }
 
         return rpc_callback->fn(service, rpc_callback, hdr->payload);
-    } else {
+    }
+    else {
         panic("Unsupported command type\n");
     }
 
@@ -393,7 +395,7 @@ void ivshm_exit_rpc(struct ivshm_info *info)
     printlk(LK_VERBOSE, "%s: entry\n", __PRETTY_FUNCTION__);
 
     list_for_every_entry_safe(&rpc_service_list, service, temp,
-                         struct ivshm_rpc_service, node) {
+                              struct ivshm_rpc_service, node) {
 
         list_delete(&service->node);
         free(service->buf);
@@ -434,13 +436,13 @@ static status_t ivshm_rpc_dev_init(struct device *dev)
 
     snprintf(name, IVSHM_EP_MAX_NAME, "rpc-%u", id);
     ep = ivshm_endpoint_create(
-                name,
-                id,
-                ivshm_rpc_consume,
-                info,
-                RPC_BUFFER_SIZE,
-                sizeof(struct ivshm_rpc_service)
-                );
+             name,
+             id,
+             ivshm_rpc_consume,
+             info,
+             RPC_BUFFER_SIZE,
+             sizeof(struct ivshm_rpc_service)
+         );
 
     service = to_ivshm_rpc_service(ep);
     memset(service, 0, sizeof(struct ivshm_rpc_service));

--- a/dev/ivshmem/services/serial/include/ivshmem-serial.h
+++ b/dev/ivshmem/services/serial/include/ivshmem-serial.h
@@ -2,6 +2,7 @@
 #ifndef __IVSHMEM_SERIAL_H
 #define __IVSHMEM_SERIAL_H
 #include <stddef.h>
+#include <compiler.h>
 
 __BEGIN_CDECLS
 
@@ -34,6 +35,16 @@ void ivshm_exit_serial(struct ivshm_info *);
  * \return int NO_ERROR if succesful, otherwise error code
  */
 int ivshm_serial_register_rx_cb(unsigned id, ivshm_serial_rx_cb_t cb);
+
+/*!
+ * \brief Un-register whatever callback is registered for this id
+ * If no callback is registered, this has no effect.
+ * 
+ * \param id the ivshmem instance to do this action on.  Must be the same as
+ * the "id" field in the device tree.
+ * \return int NO_ERROR if this port id was found, otherwise ERR_NOT_FOUND
+ */
+int ivshm_serial_unregister_rx_cb(unsigned id);
 
 /*!
  * \brief Put one char into an ivshmem serial stream

--- a/dev/ivshmem/services/serial/include/ivshmem-serial.h
+++ b/dev/ivshmem/services/serial/include/ivshmem-serial.h
@@ -3,23 +3,65 @@
 #define __IVSHMEM_SERIAL_H
 #include <stddef.h>
 
+__BEGIN_CDECLS
+
+#define IVSHM_SERIAL_RX_CB_MAX_LEN (64)
+
+typedef void (*ivshm_serial_rx_cb_t)(unsigned ept_id, char *data, uint16_t len);
+
 struct ivshm_info;
 
 int ivshm_init_serial(struct ivshm_info *);
 void ivshm_exit_serial(struct ivshm_info *);
 
 /*!
+ * \brief Register a handler to be called on receipt of data.
+ * By default, the serial service will start in buffered mode, wehre
+ * received data is stored in the service's internal ring buffer and
+ * must be retreived by calls to ivshm_serial_getchars() or
+ * ivshm_serial_getchars_noblock().
+ * 
+ * By registering a callback, buffered mode is disabled and the
+ * callback is responsible for handling incoming data.
+ * 
+ * If data is already in the internal buffer when the callback is
+ * registered, this function will drain the internal buffer to the
+ * callback before proceeding.
+ * 
+ * \param id The ivshm serial instance id, equal to "id" parameter
+ * in device tree
+ * \param cb Function to call on receipt of data
+ * \return int NO_ERROR if succesful, otherwise error code
+ */
+int ivshm_serial_register_rx_cb(unsigned id, ivshm_serial_rx_cb_t cb);
+
+/*!
  * \brief Put one char into an ivshmem serial stream
  * 
  * \param id Endpoint id of the ivshm serial path
+ * (same as "id" field in device tree entry)
  * \param c The char to sent
  * \return int The actual number of bytes sent
  */
-int ivshm_putchar(unsigned id, char c);
+int ivshm_serial_putchar(unsigned id, char c);
 
-int ivshm_getchar_noblock(char *out);
+/*!
+ * \brief Get chars from the ivshmem internal circular buffer.
+ * If there is no data available will return immediately.
+ * 
+ * \param id The ivshm serial instance id, equal to "id" parameter
+ * in device tree
+ * \param buf target buffer where data will be written
+ * \param buflen size of the target buffer
+ * \return int number of bytes actually written, or error code
+ */
+int ivshm_serial_getchars_noblock(unsigned id, char *buf, uint16_t buflen);
+
+
 void ivshm_acquire_lock(void);
 void ivshm_release_lock(void);
+
+__END_CDECLS
 
 #endif //__IVSHMEM_SERIAL_H
 

--- a/dev/ivshmem/services/serial/include/ivshmem-serial.h
+++ b/dev/ivshmem/services/serial/include/ivshmem-serial.h
@@ -1,0 +1,13 @@
+
+#ifndef __IVSHMEM_SERIAL_H
+#define __IVSHMEM_SERIAL_H
+#include <stddef.h>
+
+struct ivshm_info;
+
+int ivshm_init_serial(struct ivshm_info *);
+void ivshm_exit_serial(struct ivshm_info *);
+
+#endif //__IVSHMEM_SERIAL_H
+
+

--- a/dev/ivshmem/services/serial/include/ivshmem-serial.h
+++ b/dev/ivshmem/services/serial/include/ivshmem-serial.h
@@ -42,7 +42,7 @@ int ivshm_serial_register_rx_cb(unsigned id, ivshm_serial_rx_cb_t cb);
  * 
  * \param id the ivshmem instance to do this action on.  Must be the same as
  * the "id" field in the device tree.
- * \return int NO_ERROR if this port id was found, otherwise ERR_NOT_FOUND
+ * \return int number of callbacks removed, or ERR_NOT_FOUND if id not found
  */
 int ivshm_serial_unregister_rx_cb(unsigned id);
 

--- a/dev/ivshmem/services/serial/include/ivshmem-serial.h
+++ b/dev/ivshmem/services/serial/include/ivshmem-serial.h
@@ -8,6 +8,19 @@ struct ivshm_info;
 int ivshm_init_serial(struct ivshm_info *);
 void ivshm_exit_serial(struct ivshm_info *);
 
+/*!
+ * \brief Put one char into an ivshmem serial stream
+ * 
+ * \param id Endpoint id of the ivshm serial path
+ * \param c The char to sent
+ * \return int The actual number of bytes sent
+ */
+int ivshm_putchar(unsigned id, char c);
+
+int ivshm_getchar_noblock(char *out);
+void ivshm_acquire_lock(void);
+void ivshm_release_lock(void);
+
 #endif //__IVSHMEM_SERIAL_H
 
 

--- a/dev/ivshmem/services/serial/include/ivshmem-serial.h
+++ b/dev/ivshmem/services/serial/include/ivshmem-serial.h
@@ -47,6 +47,14 @@ int ivshm_serial_register_rx_cb(unsigned id, ivshm_serial_rx_cb_t cb);
 int ivshm_serial_unregister_rx_cb(unsigned id);
 
 /*!
+ * \brief Get the service name (if any) of the given endpoint id
+ * 
+ * \param id endpoint id
+ * \return char const* name, or NULL if service not found
+ */
+char const *ivshm_serial_get_name(unsigned id);
+
+/*!
  * \brief Put one char into an ivshmem serial stream
  * 
  * \param id Endpoint id of the ivshm serial path

--- a/dev/ivshmem/services/serial/ivshmem-serial.c
+++ b/dev/ivshmem/services/serial/ivshmem-serial.c
@@ -53,7 +53,7 @@ struct ivshm_serial_service {
 // File-scope Globals
 /******************************************************************************/
 static struct list_node serial_service_list =
-        LIST_INITIAL_VALUE(serial_service_list);
+    LIST_INITIAL_VALUE(serial_service_list);
 
 /*!
  * \brief and event for signalling when the ivshmem is ready to run
@@ -64,7 +64,7 @@ static event_t ivshm_ready_evt = EVENT_INITIAL_VALUE(ivshm_ready_evt, 0, 0);
 // Forward Declarations
 /******************************************************************************/
 static inline struct ivshm_serial_service
-                        *_get_service(unsigned id);
+*_get_service(unsigned id);
 static inline void write_chars(struct ivshm_serial_service *service, char *buf, unsigned len);
 
 /******************************************************************************/
@@ -83,15 +83,15 @@ void ivshm_exit_serial(struct ivshm_info *info)
     int ret = 0;
 
     list_for_every_entry_safe(&serial_service_list, service, next,
-        struct ivshm_serial_service, node) {
-            service->running = false;
-            thread_join(service->thread, &ret, 5000);
-            mutex_destroy(&service->tx_lock);
-            free(service->tx_cbuf.buf);
-            ivshm_endpoint_destroy(service->ept);
-            list_delete(&service->node);
-            free(service);
-        }
+                              struct ivshm_serial_service, node) {
+        service->running = false;
+        thread_join(service->thread, &ret, 5000);
+        mutex_destroy(&service->tx_lock);
+        free(service->tx_cbuf.buf);
+        ivshm_endpoint_destroy(service->ept);
+        list_delete(&service->node);
+        free(service);
+    }
 }
 
 int ivshm_serial_putchar(unsigned id, char c)
@@ -100,7 +100,7 @@ int ivshm_serial_putchar(unsigned id, char c)
     int ret = 0;
 
     service = _get_service(id);
-    if(!service) {
+    if (!service) {
         return ERR_NOT_FOUND;
     }
 
@@ -112,8 +112,7 @@ int ivshm_serial_putchar(unsigned id, char c)
 
     // If buffer is empty, send directly
     size_t used = cbuf_space_used(cbuf);
-    if( 0 == used )
-    {
+    if ( 0 == used ) {
         write_chars(service, &c, 1);
         ret = 1;
         goto unlock;
@@ -121,8 +120,7 @@ int ivshm_serial_putchar(unsigned id, char c)
 
     // Otherwise, if buffer is full return ERR and drop char
     size_t avail = cbuf_space_avail(cbuf);
-    if( 0 == avail )
-    {
+    if ( 0 == avail ) {
         ret = -1;
         goto unlock;
     }
@@ -142,12 +140,12 @@ inline int ivshm_getchar_noblock(char *out)
 
 int ivshm_serial_register_rx_cb(unsigned id, ivshm_serial_rx_cb_t cb)
 {
-    if(!cb){
+    if (!cb) {
         return ERR_INVALID_ARGS;
     }
 
     struct ivshm_serial_service *service = _get_service(id);
-    if( !service ) {
+    if ( !service ) {
         return ERR_NOT_FOUND;
     }
 
@@ -158,18 +156,16 @@ int ivshm_serial_register_rx_cb(unsigned id, ivshm_serial_rx_cb_t cb)
     mutex_acquire(&service->rx_cbuf_lock);
     size_t nchars_buffered = cbuf_space_used(&service->rx_cbuf);
     char tmpbuf[IVSHM_SERIAL_RX_CB_MAX_LEN];
-    while( nchars_buffered > 0 ) 
-    {
+    while ( nchars_buffered > 0 ) {
         size_t n_2_read;
-        if( nchars_buffered > IVSHM_SERIAL_RX_CB_MAX_LEN ) 
-        {
+        if ( nchars_buffered > IVSHM_SERIAL_RX_CB_MAX_LEN ) {
             n_2_read = IVSHM_SERIAL_RX_CB_MAX_LEN;
-        } else 
-        {
+        }
+        else {
             n_2_read = nchars_buffered;
         }
         size_t n_read = cbuf_read(&service->rx_cbuf, tmpbuf, n_2_read, true);
-        
+
         cb(id, tmpbuf, n_read);
 
         nchars_buffered -= n_read;
@@ -183,13 +179,12 @@ int ivshm_serial_register_rx_cb(unsigned id, ivshm_serial_rx_cb_t cb)
 int ivshm_serial_unregister_rx_cb(unsigned id)
 {
     struct ivshm_serial_service *service = _get_service(id);
-    if( !service ) {
+    if ( !service ) {
         return ERR_NOT_FOUND;
     }
 
     int ret = 0;
-    if( service->rx_cb )
-    {
+    if ( service->rx_cb ) {
         ret = 1;
     }
     service->buffer_rx = true;
@@ -200,7 +195,7 @@ int ivshm_serial_unregister_rx_cb(unsigned id)
 char const *ivshm_serial_get_name(unsigned id)
 {
     struct ivshm_serial_service *service = _get_service(id);
-    if( !service ) {
+    if ( !service ) {
         return NULL;
     }
 
@@ -211,24 +206,25 @@ int ivshm_serial_getchars_noblock(unsigned id, char *buf, uint16_t buflen)
 {
     int ret = 0;
 
-    if(!buf) {
+    if (!buf) {
         return ERR_NO_MEMORY;
     }
 
     struct ivshm_serial_service *service = _get_service(id);
-    if(!service) {
+    if (!service) {
         return ERR_NOT_FOUND;
     }
 
     mutex_acquire(&service->rx_cbuf_lock);
     size_t n_2_read = cbuf_space_used(&service->rx_cbuf);
-    if( n_2_read > 0 ){
-        if( n_2_read > buflen ) {
+    if ( n_2_read > 0 ) {
+        if ( n_2_read > buflen ) {
             n_2_read = buflen;
         }
 
         ret = cbuf_read(&service->rx_cbuf, buf, n_2_read, false);
-    } else {
+    }
+    else {
         ret = 0;
     }
     mutex_release(&service->rx_cbuf_lock);
@@ -259,19 +255,16 @@ static ssize_t ivshm_serial_consume(struct ivshm_endpoint *ep, struct ivshm_pkt 
 
     // get the service struct and either buffer or send it to callback
     struct ivshm_serial_service *service = _get_service(id);
-    if( service->buffer_rx )
-    {
+    if ( service->buffer_rx ) {
         // service in buffered mode so put data into the buffer
         mutex_acquire(&service->rx_cbuf_lock);
         size_t n_buffered = cbuf_write(&service->rx_cbuf, payload, len, true);
         mutex_release(&service->rx_cbuf_lock);
         DEBUG_ASSERT( n_buffered == len );
     }
-    else
-    {
+    else {
         // we're in callback mode
-        if( service->rx_cb ) 
-        {
+        if ( service->rx_cb ) {
             service->rx_cb(id, payload, len);
         }
     }
@@ -279,13 +272,12 @@ static ssize_t ivshm_serial_consume(struct ivshm_endpoint *ep, struct ivshm_pkt 
 }
 
 static inline struct ivshm_serial_service
-                        *_get_service(unsigned id)
+*_get_service(unsigned id)
 {
     struct ivshm_serial_service *service;
 
     list_for_every_entry(&serial_service_list, service,
-                         struct ivshm_serial_service, node) 
-    {
+                         struct ivshm_serial_service, node) {
         if (service->id == id)
             return service;
     }
@@ -302,8 +294,7 @@ static int ivshm_serial_tx_thread(void *arg)
     iovec_t regions[2];
     size_t payload_sz;
 
-    while (service->running) 
-    {      
+    while (service->running) {
         ivshm_ep_buf_init(&ep_buf);
         event_wait(&service->tx_cbuf.event);
         payload_sz = cbuf_peek(&service->tx_cbuf, regions);
@@ -324,20 +315,20 @@ static int ivshm_serial_tx_thread(void *arg)
 static inline void print_err_property(char *property_name)
 {
     printlk(LK_ERR, "%s:%d: Endpoint %s property cannot be read, aborting!\n",
-        __PRETTY_FUNCTION__, __LINE__, property_name);
+            __PRETTY_FUNCTION__, __LINE__, property_name);
 }
 
 static status_t ivshm_serial_dev_init(struct device *dev)
 {
     int ret = NO_ERROR;
     char *property_name = NULL;
-    char * cbuf_mem = NULL;
+    char *cbuf_mem = NULL;
     char name[IVSHM_EP_MAX_NAME];
     uint32_t id, ep_size;
     struct ivshm_serial_service *service = NULL;
 
     struct ivshm_dev_data *ivshm_dev = ivshm_get_device(0);
-    if(!ivshm_dev) {
+    if (!ivshm_dev) {
         return ERR_NOT_READY;
     }
 
@@ -346,16 +337,16 @@ static status_t ivshm_serial_dev_init(struct device *dev)
         return ERR_NOT_READY;
     }
 
-    property_name = (char*)"id";
+    property_name = (char *)"id";
     ret = of_device_get_int32(dev, property_name, &id);
-    if(ret) {
+    if (ret) {
         print_err_property(property_name);
         return ERR_NOT_FOUND;
     }
 
-    property_name = (char*)"size";
+    property_name = (char *)"size";
     ret = of_device_get_int32(dev, property_name, &ep_size);
-    if(ret) {
+    if (ret) {
         print_err_property(property_name);
         return ERR_NOT_FOUND;
     }
@@ -363,16 +354,16 @@ static status_t ivshm_serial_dev_init(struct device *dev)
     DEBUG_ASSERT(ep_size < IVSHM_MAX_CBUF_SIZE);
 
     service = malloc(sizeof(struct ivshm_serial_service));
-    if(!service) {
+    if (!service) {
         ret = ERR_NO_MEMORY;
         goto cleanup;
     }
-    
+
     memset(service, 0, sizeof(struct ivshm_serial_service));
 
-    property_name = (char*)"id_str";
+    property_name = (char *)"id_str";
     ret = of_device_get_strings(dev, property_name, &service->name, 1);
-    if( 1 != ret ) {
+    if ( 1 != ret ) {
         TRACEF("Failed to get id_str!\n");
         ret = ERR_NOT_FOUND;
         goto cleanup;
@@ -381,38 +372,38 @@ static status_t ivshm_serial_dev_init(struct device *dev)
     service->id = id;
     snprintf(name, IVSHM_EP_MAX_NAME, "serial_%u_%s", service->id, service->name);
     service->ept = ivshm_endpoint_create(
-            name,
-            service->id,
-            ivshm_serial_consume,
-            info,
-            ep_size,
-            0 // fixme
-        );
-    
-    if(!service->ept) {
+                       name,
+                       service->id,
+                       ivshm_serial_consume,
+                       info,
+                       ep_size,
+                       0 // fixme
+                   );
+
+    if (!service->ept) {
         ret = ERR_NO_MEMORY;
         goto cleanup;
     }
 
     printf("\n%s:%u: new endpoint id = %u\n", __PRETTY_FUNCTION__, __LINE__,
-        IVSHM_EP_GET_ID(service->ept->id) );
+           IVSHM_EP_GET_ID(service->ept->id) );
 
     // Setup tx thread to transmit queued buffers
-    char const * prefix = "ivshm-serial";
+    char const *prefix = "ivshm-serial";
     char name_buf[32];
     size_t len = strnlen(prefix, 32);
     memcpy(name_buf, prefix, len);
     snprintf(name_buf + len, 32-len, "%u", id);
     service->thread = thread_create(
-        name_buf,
-        ivshm_serial_tx_thread,
-        (void*)service,
-        IVSHM_EP_GET_PRIO(service->ept->id),
-        DEFAULT_STACK_SIZE );
+                          name_buf,
+                          ivshm_serial_tx_thread,
+                          (void *)service,
+                          IVSHM_EP_GET_PRIO(service->ept->id),
+                          DEFAULT_STACK_SIZE );
 
     // initialize tx circ buffer
     cbuf_mem = malloc(ep_size);
-    if(!cbuf_mem) {
+    if (!cbuf_mem) {
         ret = ERR_NO_MEMORY;
         goto cleanup;
     }
@@ -421,7 +412,7 @@ static status_t ivshm_serial_dev_init(struct device *dev)
     // initialize the rx circ buffer
     cbuf_mem = NULL;
     cbuf_mem = malloc(ep_size);
-    if(!cbuf_mem) {
+    if (!cbuf_mem) {
         ret = ERR_NO_MEMORY;
         goto cleanup;
     }
@@ -429,7 +420,7 @@ static status_t ivshm_serial_dev_init(struct device *dev)
 
     // initialize tx buffer
     service->tx_buf = malloc(IVSHM_SERIAL_TX_BUF_SIZE);
-    if(!service->tx_buf) {
+    if (!service->tx_buf) {
         ret = ERR_NO_MEMORY;
         goto cleanup;
     }
@@ -444,15 +435,15 @@ static status_t ivshm_serial_dev_init(struct device *dev)
     return ret;
 
 cleanup:
-    if(service->tx_buf) { free(service->tx_buf); }
-    if(service->rx_cbuf.buf) { free(service->rx_cbuf.buf); }
-    if(service->tx_cbuf.buf) { free(service->tx_cbuf.buf); }
-    if(service->ept) { ivshm_endpoint_destroy(service->ept); }
-    if(service->thread) {
+    if (service->tx_buf) { free(service->tx_buf); }
+    if (service->rx_cbuf.buf) { free(service->rx_cbuf.buf); }
+    if (service->tx_cbuf.buf) { free(service->tx_cbuf.buf); }
+    if (service->ept) { ivshm_endpoint_destroy(service->ept); }
+    if (service->thread) {
         thread_join(service->thread, NULL, 5000);
         free(service->thread);
     }
-    if(service) { free(service); }
+    if (service) { free(service); }
 
     return ret;
 }

--- a/dev/ivshmem/services/serial/ivshmem-serial.c
+++ b/dev/ivshmem/services/serial/ivshmem-serial.c
@@ -187,9 +187,14 @@ int ivshm_serial_unregister_rx_cb(unsigned id)
         return ERR_NOT_FOUND;
     }
 
+    int ret = 0;
+    if( service->rx_cb )
+    {
+        ret = 1;
+    }
     service->buffer_rx = true;
     service->rx_cb = NULL;
-    return 0;
+    return ret;
 }
 
 char const *ivshm_serial_get_name(unsigned id)

--- a/dev/ivshmem/services/serial/ivshmem-serial.c
+++ b/dev/ivshmem/services/serial/ivshmem-serial.c
@@ -5,20 +5,53 @@
 #include "ivshmem-serial.h"
 #include <debug.h>
 #include <assert.h>
-// #include <lib/klog.h>
 #include <stdio.h>
+#include <lib/cbuf.h>
+#include <lk/init.h>
+#include <lib/io.h>
+#include <string.h>
+#include <kernel/mutex.h>
+#include <lib/console.h>
+#include <string.h>
+
+struct ivshm_serial {
+    mutex_t tx_lock;
+    cbuf_t tx_cbuf;
+    thread_t *thread;
+    bool running;
+    struct ivshm_endpoint *ep;
+};
+
+#ifndef IVSHM_SERIAL_BUFFER_SIZE
+#define IVSHM_SERIAL_BUFFER_SIZE (16 * 1024)
+#endif
+#ifndef IVSHM_LOGGER_BUF_SIZE
+#define IVSHM_LOGGER_BUF_SIZE 4096
+#endif
 
 static struct ivshm_endpoint *ep_serial;
+static char ivshm_serial_buf[IVSHM_SERIAL_BUFFER_SIZE];
+
+#define IVSHM_SERIAL_TX_BUF_SIZE (64)
+static char txbuf[IVSHM_SERIAL_TX_BUF_SIZE];
+
+static struct ivshm_serial _ivshm_serial;
+static struct ivshm_serial *_con = &_ivshm_serial;
 
 #define MIN(x, y) ((x < y) ? x : y)
 
-#define IVSHM_SERIAL_ECHO_BUF_SIZE (512)
-
-#include <lib/console.h>
-#include <string.h>
 static void ivshm_start_serial(struct ivshm_endpoint *);
 static void ivshm_stop_serial(struct ivshm_endpoint *);
 
+static inline void write_chars(struct ivshm_endpoint *ep, char *buf, unsigned len)
+{
+    ASSERT( len <= IVSHM_SERIAL_TX_BUF_SIZE);
+    struct ivshm_ep_buf ep_buf;
+    memcpy(txbuf, buf, len);
+    ivshm_ep_buf_init(&ep_buf);
+    ivshm_ep_buf_add(&ep_buf, txbuf, len);
+    ivshm_endpoint_write(ep, &ep_buf);
+}
 
 static ssize_t ivshm_serial_consume(struct ivshm_endpoint *ep, struct ivshm_pkt *pkt)
 {
@@ -29,13 +62,10 @@ static ssize_t ivshm_serial_consume(struct ivshm_endpoint *ep, struct ivshm_pkt 
           len, strnlen(payload, len), payload);
 
     // echo back
-    struct ivshm_ep_buf ep_buf;
-    static char buf[IVSHM_SERIAL_ECHO_BUF_SIZE];
-    memcpy(buf, payload, len);
-    ivshm_ep_buf_init(&ep_buf);
-    ivshm_ep_buf_add(&ep_buf, buf, len);
-    ivshm_endpoint_write(ep, &ep_buf);
-
+    for(unsigned i=0; i<len; ++i)
+    {
+        ivshm_putchar(payload[i]);
+    }
     return 0;
 }
 
@@ -63,32 +93,41 @@ void ivshm_exit_serial(struct ivshm_info *info)
     ivshm_endpoint_destroy(ep_serial);
 }
 
-#include <lk/init.h>
-#include <lib/cbuf.h>
-#include <lib/io.h>
-#include <string.h>
+inline int ivshm_putchar(char c)
+{
+    // If buffer is empty, send directly
+    size_t used = cbuf_space_used(&_con->tx_cbuf);
+    if( 0 == used )
+    {
+        write_chars(ep_serial, &c, 1);
+        return 1;
+    }
 
-struct ivshm_serial {
-    print_callback_t print_cb;
-    spin_lock_t tx_lock;
-    cbuf_t tx_buf;
-    thread_t *thread;
-    bool running;
-    struct ivshm_endpoint *ep;
-};
+    // Otherwise, if buffer is full return ERR and drop char
+    size_t avail = cbuf_space_avail(&_con->tx_cbuf);
+    if( 0 == avail )
+    {
+        return -1;
+    }
 
-#ifndef IVSHM_SERIAL_BUFFER_SIZE
-#define IVSHM_SERIAL_BUFFER_SIZE (16 * 1024)
-#endif
-#ifndef IVSHM_LOGGER_BUF_SIZE
-#define IVSHM_LOGGER_BUF_SIZE 4096
-#endif
+    // Otherwise, put char onto buff
+    return cbuf_write_char(&_con->tx_cbuf, c, false);
+}
 
+inline int ivshm_getchar_noblock(char *out)
+{
+    return 0;
+}
 
-static char ivshm_serial_buf[IVSHM_SERIAL_BUFFER_SIZE];
+void ivshm_acquire_lock(void)
+{
+    mutex_acquire(&_con->tx_lock);
+}
 
-static struct ivshm_serial _ivshm_serial;
-static struct ivshm_serial *_con = &_ivshm_serial;
+void ivshm_release_lock(void)
+{
+    mutex_release(&_con->tx_lock);
+}
 
 static int ivshm_serial_thread(void *arg)
 {
@@ -99,24 +138,23 @@ static int ivshm_serial_thread(void *arg)
     size_t payload_sz;
 
     while (con->running) 
-    {
+    {      
         thread_yield();
-        // ivshm_ep_buf_init(&ep_buf);
-        // event_wait(&con->tx_buf.event);
-        // payload_sz = cbuf_peek(&con->tx_buf, regions);
-        // DEBUG_ASSERT(payload_sz > 0);
-        // ivshm_ep_buf_add(&ep_buf, regions[0].iov_base, regions[0].iov_len);
-        // if (regions[1].iov_len)
-        //     ivshm_ep_buf_add(&ep_buf, regions[1].iov_base, regions[1].iov_len);
+        ivshm_ep_buf_init(&ep_buf);
+        event_wait(&con->tx_cbuf.event);
+        payload_sz = cbuf_peek(&con->tx_cbuf, regions);
+        DEBUG_ASSERT(payload_sz > 0);
+        ivshm_ep_buf_add(&ep_buf, regions[0].iov_base, regions[0].iov_len);
+        if (regions[1].iov_len)
+            ivshm_ep_buf_add(&ep_buf, regions[1].iov_base, regions[1].iov_len);
 
-        // ivshm_endpoint_write(con->ep, &ep_buf);
+        ivshm_endpoint_write(con->ep, &ep_buf);
 
-        // cbuf_read(&con->tx_buf, NULL, payload_sz, false);
+        cbuf_read(&con->tx_cbuf, NULL, payload_sz, false);
     }
 
     return 0;
 }
-
 
 static void ivshm_start_serial(struct ivshm_endpoint *ep)
 {
@@ -147,24 +185,13 @@ static void ivshm_stop_serial(struct ivshm_endpoint *ep)
     thread_join(con->thread, &retcode, 1000);
 }
 
-static void ivshm_serial_print(print_callback_t *cb, const char *str, size_t len)
-{
-    struct ivshm_serial *con = cb->context;
-    cbuf_write(&con->tx_buf, str, len, false);
-}
-
 static void ivshm_hook_serial_init(unsigned level)
 {
     memset(_con, 0x0, sizeof(*_con));
 
-    cbuf_initialize_etc(&_con->tx_buf, IVSHM_SERIAL_BUFFER_SIZE, &ivshm_serial_buf);
+    cbuf_initialize_etc(&_con->tx_cbuf, IVSHM_SERIAL_BUFFER_SIZE, &ivshm_serial_buf);
 
-    spin_lock_init(&_con->tx_lock);
-
-    _con->print_cb.print = ivshm_serial_print;
-    _con->print_cb.context = _con;
-
-    register_print_callback(&_con->print_cb);
+    mutex_init(&_con->tx_lock);
 }
 
 LK_INIT_HOOK(ivshm_serial, ivshm_hook_serial_init, LK_INIT_LEVEL_PLATFORM_EARLY - 1);

--- a/dev/ivshmem/services/serial/ivshmem-serial.c
+++ b/dev/ivshmem/services/serial/ivshmem-serial.c
@@ -9,48 +9,51 @@
 #include <lib/cbuf.h>
 #include <lk/init.h>
 #include <lib/io.h>
+#include <lib/appargs.h>
 #include <string.h>
 #include <kernel/mutex.h>
 #include <lib/console.h>
-#include <string.h>
+#include <dev/driver.h>
+#include <dev/ivshm.h>
+#include <err.h>
 
-struct ivshm_serial {
+#include <string.h>
+#include <stdlib.h>
+
+struct ivshm_serial_service {
+    struct list_node node;
+    unsigned id;
+    struct ivshm_endpoint *ept;
     mutex_t tx_lock;
     cbuf_t tx_cbuf;
     thread_t *thread;
     bool running;
-    struct ivshm_endpoint *ep;
+    char *tx_buf;
 };
 
-#ifndef IVSHM_SERIAL_BUFFER_SIZE
-#define IVSHM_SERIAL_BUFFER_SIZE (16 * 1024)
-#endif
-#ifndef IVSHM_LOGGER_BUF_SIZE
-#define IVSHM_LOGGER_BUF_SIZE 4096
-#endif
-
-static struct ivshm_endpoint *ep_serial;
-static char ivshm_serial_buf[IVSHM_SERIAL_BUFFER_SIZE];
+#define IVSHM_MAX_CBUF_SIZE (1024 * 64)
 
 #define IVSHM_SERIAL_TX_BUF_SIZE (64)
-static char txbuf[IVSHM_SERIAL_TX_BUF_SIZE];
 
-static struct ivshm_serial _ivshm_serial;
-static struct ivshm_serial *_con = &_ivshm_serial;
+static struct list_node serial_service_list =
+        LIST_INITIAL_VALUE(serial_service_list);
 
-#define MIN(x, y) ((x < y) ? x : y)
+/*!
+ * \brief and event for signalling when the ivshmem is ready to run
+ */
+static event_t ivshm_ready_evt = EVENT_INITIAL_VALUE(ivshm_ready_evt, 0, 0);
+
 
 static void ivshm_start_serial(struct ivshm_endpoint *);
-static void ivshm_stop_serial(struct ivshm_endpoint *);
 
-static inline void write_chars(struct ivshm_endpoint *ep, char *buf, unsigned len)
+static inline void write_chars(struct ivshm_serial_service *service, char *buf, unsigned len)
 {
     ASSERT( len <= IVSHM_SERIAL_TX_BUF_SIZE);
     struct ivshm_ep_buf ep_buf;
-    memcpy(txbuf, buf, len);
+    memcpy(service->tx_buf, buf, len);
     ivshm_ep_buf_init(&ep_buf);
-    ivshm_ep_buf_add(&ep_buf, txbuf, len);
-    ivshm_endpoint_write(ep, &ep_buf);
+    ivshm_ep_buf_add(&ep_buf, service->tx_buf, len);
+    ivshm_endpoint_write(service->ept, &ep_buf);
 }
 
 static ssize_t ivshm_serial_consume(struct ivshm_endpoint *ep, struct ivshm_pkt *pkt)
@@ -61,57 +64,108 @@ static ssize_t ivshm_serial_consume(struct ivshm_endpoint *ep, struct ivshm_pkt 
     printf("payload : %lu bytes strlen %lu, content: %s",
           len, strnlen(payload, len), payload);
 
-    // echo back
     for(unsigned i=0; i<len; ++i)
     {
-        ivshm_putchar(payload[i]);
+        ivshm_putchar(ep->id, payload[i]);
     }
     return 0;
 }
 
 int ivshm_init_serial(struct ivshm_info *info)
 {
-    ep_serial = ivshm_endpoint_create(
-                 "ivshm_serial",
-                 IVSHM_EP_ID_SERIAL,
-                 ivshm_serial_consume,
-                 info,
-                 8 * 1024,
-                 0
-             );
+    event_signal(&ivshm_ready_evt, false);
 
-    DEBUG_ASSERT(NULL != ep_serial );
+    // ep_serial = ivshm_endpoint_create(
+    //              "ivshm_serial",
+    //              IVSHM_EP_ID_SERIAL,
+    //              ivshm_serial_consume,
+    //              info,
+    //              8 * 1024,
+    //              0
+    //          );
 
-    ivshm_start_serial(ep_serial);
+    // DEBUG_ASSERT(NULL != ep_serial );
+
+    // ivshm_start_serial(ep_serial);
 
     return 0;
 }
 
 void ivshm_exit_serial(struct ivshm_info *info)
 {
-    ivshm_stop_serial(ep_serial);
-    ivshm_endpoint_destroy(ep_serial);
+    // ivshm_stop_serial(ep_serial);
+    // ivshm_endpoint_destroy(ep_serial);
+    struct ivshm_serial_service *service, *next;
+    int ret = 0;
+
+    list_for_every_entry_safe(&serial_service_list, service, next,
+        struct ivshm_serial_service, node) {
+            service->running = false;
+            thread_join(service->thread, &ret, 5000);
+            // mutex_destroy(&service->tx_lock);
+            free(service->tx_cbuf.buf);
+            ivshm_endpoint_destroy(service->ept);
+            list_delete(&service->node);
+            free(service);
+        }
 }
 
-inline int ivshm_putchar(char c)
+static inline struct ivshm_serial_service
+                        *_ivshm_serial_get_service(unsigned id)
 {
+    struct ivshm_serial_service *service;
+
+    list_for_every_entry(&serial_service_list, service,
+                         struct ivshm_serial_service, node) 
+    {
+        if (service->id == id)
+            return service;
+    }
+
+    printlk(LK_ERR, "%s:%d: Could not find serial-%d endpoint\n",
+            __PRETTY_FUNCTION__, __LINE__, id);
+    return NULL;
+}
+
+int ivshm_putchar(unsigned id, char c)
+{
+    struct ivshm_serial_service *service;
+    int ret = 0;
+
+    service = _ivshm_serial_get_service(id);
+    if(!service) {
+        return ERR_NOT_FOUND;
+    }
+
+    // get the tx_cbuf for this id
+    cbuf_t *cbuf = &service->tx_cbuf;
+
+    // get the lock
+    mutex_acquire(&service->tx_lock);
+
     // If buffer is empty, send directly
-    size_t used = cbuf_space_used(&_con->tx_cbuf);
+    size_t used = cbuf_space_used(cbuf);
     if( 0 == used )
     {
-        write_chars(ep_serial, &c, 1);
-        return 1;
+        write_chars(service, &c, 1);
+        ret = 1;
+        goto unlock;
     }
 
     // Otherwise, if buffer is full return ERR and drop char
-    size_t avail = cbuf_space_avail(&_con->tx_cbuf);
+    size_t avail = cbuf_space_avail(cbuf);
     if( 0 == avail )
     {
-        return -1;
+        ret = -1;
+        goto unlock;
     }
 
     // Otherwise, put char onto buff
-    return cbuf_write_char(&_con->tx_cbuf, c, false);
+    ret = cbuf_write_char(cbuf, c, false);
+
+unlock:
+    mutex_release(&service->tx_lock);
+    return ret;
 }
 
 inline int ivshm_getchar_noblock(char *out)
@@ -119,38 +173,28 @@ inline int ivshm_getchar_noblock(char *out)
     return 0;
 }
 
-void ivshm_acquire_lock(void)
-{
-    mutex_acquire(&_con->tx_lock);
-}
-
-void ivshm_release_lock(void)
-{
-    mutex_release(&_con->tx_lock);
-}
-
-static int ivshm_serial_thread(void *arg)
+static int ivshm_serial_tx_thread(void *arg)
 {
 
-    struct ivshm_serial *con = arg;
+    struct ivshm_serial_service *service = arg;
     struct ivshm_ep_buf ep_buf;
     iovec_t regions[2];
     size_t payload_sz;
 
-    while (con->running) 
+    while (service->running) 
     {      
-        thread_yield();
         ivshm_ep_buf_init(&ep_buf);
-        event_wait(&con->tx_cbuf.event);
-        payload_sz = cbuf_peek(&con->tx_cbuf, regions);
+        event_wait(&service->tx_cbuf.event);
+        payload_sz = cbuf_peek(&service->tx_cbuf, regions);
         DEBUG_ASSERT(payload_sz > 0);
         ivshm_ep_buf_add(&ep_buf, regions[0].iov_base, regions[0].iov_len);
         if (regions[1].iov_len)
             ivshm_ep_buf_add(&ep_buf, regions[1].iov_base, regions[1].iov_len);
 
-        ivshm_endpoint_write(con->ep, &ep_buf);
+        ivshm_endpoint_write(service->ept, &ep_buf);
 
-        cbuf_read(&con->tx_cbuf, NULL, payload_sz, false);
+        cbuf_read(&service->tx_cbuf, NULL, payload_sz, false);
+        thread_yield();
     }
 
     return 0;
@@ -158,42 +202,154 @@ static int ivshm_serial_thread(void *arg)
 
 static void ivshm_start_serial(struct ivshm_endpoint *ep)
 {
+    
 
-    struct ivshm_serial *con = _con;
+    // struct ivshm_serial *con = _con;
 
-    con->thread = thread_create(
-                    "ivshm_serial_thread",
-                    ivshm_serial_thread,
-                    (void *) con,
-                    LOW_PRIORITY - 1,
-                    IVSHM_LOGGER_BUF_SIZE +  4096
-                 );
+    // con->thread = thread_create(
+    //                 "ivshm_serial_thread",
+    //                 ivshm_serial_thread,
+    //                 (void *) con,
+    //                 LOW_PRIORITY - 1,
+    //                 IVSHM_LOGGER_BUF_SIZE +  4096
+    //              );
 
-    con->running = true;
-    con->ep = ep;
-    smp_wmb();
-    thread_resume(con->thread);
+    // con->running = true;
+    // con->ep = ep;
+    // smp_wmb();
+    // thread_resume(con->thread);
 }
 
-static void ivshm_stop_serial(struct ivshm_endpoint *ep)
-{
-    struct ivshm_serial *con = _con;
-    int retcode;
+// static void ivshm_stop_serial(struct ivshm_endpoint *ep)
+// {
+//     struct ivshm_serial *con = _con;
+//     int retcode;
 
-    con->running = false;
-    smp_wmb();
-    thread_join(con->thread, &retcode, 1000);
-}
+//     con->running = false;
+//     smp_wmb();
+//     thread_join(con->thread, &retcode, 1000);
+// }
 
 static void ivshm_hook_serial_init(unsigned level)
 {
-    memset(_con, 0x0, sizeof(*_con));
+    // memset(_con, 0x0, sizeof(*_con));
 
-    cbuf_initialize_etc(&_con->tx_cbuf, IVSHM_SERIAL_BUFFER_SIZE, &ivshm_serial_buf);
+    // cbuf_initialize_etc(&_con->tx_cbuf, IVSHM_SERIAL_BUFFER_SIZE, &ivshm_serial_buf);
 
-    mutex_init(&_con->tx_lock);
+    // mutex_init(&_con->tx_lock);
 }
 
-LK_INIT_HOOK(ivshm_serial, ivshm_hook_serial_init, LK_INIT_LEVEL_PLATFORM_EARLY - 1);
+static inline void print_err_property(char *property_name)
+{
+    printlk(LK_ERR, "%s:%d: Endpoint %s property cannot be read, aborting!\n",
+        __PRETTY_FUNCTION__, __LINE__, property_name);
+}
+
+static status_t ivshm_serial_dev_init(struct device *dev)
+{
+    int ret = NO_ERROR;
+    char *property_name = NULL;
+    char * cbuf_mem = NULL;
+    char name[IVSHM_EP_MAX_NAME];
+    uint32_t id, ep_size;
+    struct ivshm_serial_service *service = NULL;
+
+    struct ivshm_dev_data *ivshm_dev = ivshm_get_device(0);
+    if(!ivshm_dev) {
+        return ERR_NOT_READY;
+    }
+
+    struct ivshm_info *info = ivshm_dev->handler_arg;
+    if (!info) {
+        return ERR_NOT_READY;
+    }
+
+    property_name = (char*)"id";
+    ret = of_device_get_int32(dev, property_name, &id);
+    if(ret) {
+        print_err_property(property_name);
+        return ERR_NOT_FOUND;
+    }
+
+    property_name = (char*)"size";
+    ret = of_device_get_int32(dev, property_name, &ep_size);
+    if(ret) {
+        print_err_property(property_name);
+        return ERR_NOT_FOUND;
+    }
+
+    DEBUG_ASSERT(ep_size < IVSHM_MAX_CBUF_SIZE);
+
+    service = malloc(sizeof(struct ivshm_serial_service));
+    if(!service) {
+        ret = ERR_NO_MEMORY;
+        goto cleanup;
+    }
+    
+    memset(service, 0, sizeof(struct ivshm_serial_service));
+
+    service->id = id;
+    snprintf(name, IVSHM_EP_MAX_NAME, "serial-%u", service->id);
+    service->ept = ivshm_endpoint_create(
+            name,
+            service->id,
+            ivshm_serial_consume,
+            info,
+            ep_size,
+            0 // fixme
+        );
+
+    // Setup tx thread to transmit queued buffers
+    char const * prefix = "ivshm-serial";
+    char name_buf[32];
+    size_t len = strnlen(prefix, 32);
+    memcpy(name_buf, prefix, len);
+    snprintf(name_buf + len, 32-len, "%u", id);
+    service->thread = thread_create(
+        name_buf,
+        ivshm_serial_tx_thread,
+        (void*)service,
+        IVSHM_EP_GET_PRIO(service->ept->id),
+        DEFAULT_STACK_SIZE );
+
+    // initialize tx circ buffer
+    cbuf_mem = malloc(ep_size);
+    if(!cbuf_mem) {
+        ret = ERR_NO_MEMORY;
+        goto cleanup;
+    }
+    cbuf_initialize_etc(&service->tx_cbuf, ep_size, cbuf_mem);
+
+    // initialize tx buffer
+    service->tx_buf = malloc(IVSHM_SERIAL_TX_BUF_SIZE);
+    if(!service->tx_buf) {
+        ret = ERR_NO_MEMORY;
+        goto cleanup;
+    }
+
+    service->running = true;
+    thread_resume(service->thread);
+    list_add_tail(&serial_service_list, &service->node);
+
+    return ret;
+
+cleanup:
+    if(service->tx_buf) { free(service->tx_buf); }
+    if(service->ept) { ivshm_endpoint_destroy(service->ept); }
+    if(service->thread) {
+        thread_join(service->thread, NULL, 5000);
+        free(service->thread);
+    }
+    if(service) { free(service); }
+
+    return ret;
+}
+
+static struct driver_ops the_ops = {
+    .init = ivshm_serial_dev_init
+};
+
+// LK_INIT_HOOK(ivshm_serial, ivshm_hook_serial_init, LK_INIT_LEVEL_PLATFORM_EARLY - 1);
+DRIVER_EXPORT_WITH_LVL(ivshm_serial, &the_ops, DRIVER_INIT_CORE);
 
 

--- a/dev/ivshmem/services/serial/ivshmem-serial.c
+++ b/dev/ivshmem/services/serial/ivshmem-serial.c
@@ -1,0 +1,156 @@
+
+
+#include "ivshmem-pipe.h"
+#include "ivshmem-endpoint.h"
+#include "ivshmem-serial.h"
+#include <debug.h>
+// #include <lib/klog.h>
+#include <stdio.h>
+
+static struct ivshm_endpoint *ep_serial;
+
+#define MIN(x, y) ((x < y) ? x : y)
+
+#include <lib/console.h>
+#include <string.h>
+static void ivshm_start_logger(struct ivshm_endpoint *);
+static void ivshm_stop_logger(struct ivshm_endpoint *);
+
+static ssize_t ivshm_serial_consume(struct ivshm_endpoint *ep, struct ivshm_pkt *pkt)
+{
+    char *payload = (char *) &pkt->payload;
+    size_t len = ivshm_pkt_get_payload_length(pkt);
+
+    printf("payload : %lu bytes strlen %lu, content: %s",
+          len, strnlen(payload, len), payload);
+
+    return 0;
+}
+
+int ivshm_init_serial(struct ivshm_info *info)
+{
+    ep_serial = ivshm_endpoint_create(
+                 "ivshm_serial",
+                 IVSHM_EP_ID_SERIAL,
+                 ivshm_serial_consume,
+                 info,
+                 8 * 1024,
+                 0
+             );
+
+    ivshm_start_logger(ep_serial);
+
+    return 0;
+}
+
+void ivshm_exit_serial(struct ivshm_info *info)
+{
+    ivshm_stop_logger(ep_serial);
+    ivshm_endpoint_destroy(ep_serial);
+}
+
+#include <lk/init.h>
+#include <lib/cbuf.h>
+#include <lib/io.h>
+#include <string.h>
+#include "assert.h"
+
+struct ivshm_serial {
+    print_callback_t print_cb;
+    spin_lock_t tx_lock;
+    cbuf_t tx_buf;
+    thread_t *thread;
+    bool running;
+    struct ivshm_endpoint *ep;
+};
+
+#ifndef IVSHM_CONSOLE_BUFFER_SIZE
+#define IVSHM_CONSOLE_BUFFER_SIZE (16 * 1024)
+#endif
+#ifndef IVSHM_LOGGER_BUF_SIZE
+#define IVSHM_LOGGER_BUF_SIZE 4096
+#endif
+
+
+static char ivshm_serial_buf[IVSHM_CONSOLE_BUFFER_SIZE];
+
+static struct ivshm_serial _ivshm_serial;
+static struct ivshm_serial *_con = &_ivshm_serial;
+
+static int ivshm_serial_thread(void *arg)
+{
+
+    struct ivshm_serial *con = arg;
+    struct ivshm_ep_buf ep_buf;
+    iovec_t regions[2];
+    size_t payload_sz;
+
+    while (con->running) {
+        ivshm_ep_buf_init(&ep_buf);
+        event_wait(&con->tx_buf.event);
+        payload_sz = cbuf_peek(&con->tx_buf, regions);
+        DEBUG_ASSERT(payload_sz > 0);
+        ivshm_ep_buf_add(&ep_buf, regions[0].iov_base, regions[0].iov_len);
+        if (regions[1].iov_len)
+            ivshm_ep_buf_add(&ep_buf, regions[1].iov_base, regions[1].iov_len);
+
+        ivshm_endpoint_write(con->ep, &ep_buf);
+
+        cbuf_read(&con->tx_buf, NULL, payload_sz, false);
+    }
+
+    return 0;
+}
+
+
+static void ivshm_start_logger(struct ivshm_endpoint *ep)
+{
+
+    struct ivshm_serial *con = _con;
+
+    con->thread = thread_create(
+                    "ivshm_serial_thread",
+                    ivshm_serial_thread,
+                    (void *) con,
+                    LOW_PRIORITY - 1,
+                    IVSHM_LOGGER_BUF_SIZE +  4096
+                 );
+
+    con->running = true;
+    con->ep = ep;
+    smp_wmb();
+    thread_resume(con->thread);
+}
+
+static void ivshm_stop_logger(struct ivshm_endpoint *ep)
+{
+    struct ivshm_serial *con = _con;
+    int retcode;
+
+    con->running = false;
+    smp_wmb();
+    thread_join(con->thread, &retcode, 1000);
+}
+
+static void ivshm_serial_print(print_callback_t *cb, const char *str, size_t len)
+{
+    struct ivshm_serial *con = cb->context;
+    cbuf_write(&con->tx_buf, str, len, false);
+}
+
+static void ivshm_hook_serial_init(unsigned level)
+{
+    memset(_con, 0x0, sizeof(*_con));
+
+    cbuf_initialize_etc(&_con->tx_buf, IVSHM_CONSOLE_BUFFER_SIZE, &ivshm_serial_buf);
+
+    spin_lock_init(&_con->tx_lock);
+
+    _con->print_cb.print = ivshm_serial_print;
+    _con->print_cb.context = _con;
+
+    register_print_callback(&_con->print_cb);
+}
+
+LK_INIT_HOOK(ivshm_serial, ivshm_hook_serial_init, LK_INIT_LEVEL_PLATFORM_EARLY - 1);
+

--- a/dev/ivshmem/services/serial/ivshmem-serial.c
+++ b/dev/ivshmem/services/serial/ivshmem-serial.c
@@ -377,7 +377,7 @@ static status_t ivshm_serial_dev_init(struct device *dev)
                        ivshm_serial_consume,
                        info,
                        ep_size,
-                       0 // fixme
+                       0
                    );
 
     if (!service->ept) {

--- a/dev/ivshmem/services/serial/ivshmem-serial.c
+++ b/dev/ivshmem/services/serial/ivshmem-serial.c
@@ -178,6 +178,17 @@ int ivshm_serial_register_rx_cb(unsigned id, ivshm_serial_rx_cb_t cb)
     return NO_ERROR;
 }
 
+int ivshm_serial_unregister_rx_cb(unsigned id)
+{
+    struct ivshm_serial_service *service = _get_service(id);
+    if( !service ) {
+        return ERR_NOT_FOUND;
+    }
+
+    service->rx_cb = NULL;
+    return 0;
+}
+
 int ivshm_serial_getchars_noblock(unsigned id, char *buf, uint16_t buflen)
 {
     int ret = 0;

--- a/dev/ivshmem/services/serial/rules.mk
+++ b/dev/ivshmem/services/serial/rules.mk
@@ -1,0 +1,9 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+MODULE := $(LOCAL_DIR)
+
+MODULE_SRCS += $(LOCAL_DIR)/ivshmem-serial.c
+
+MODULE_DEPS += dev/ivshmem
+
+include make/module.mk

--- a/project/imx8mn-dts.mk
+++ b/project/imx8mn-dts.mk
@@ -20,6 +20,7 @@ MODULES += \
         dev/ivshmem/services/console \
         dev/ivshmem/services/binary \
         dev/ivshmem/services/rpc \
+		dev/ivshmem/services/serial \
 
 MODULES += \
 	dev/pca6416 \
@@ -30,7 +31,8 @@ MODULES += \
 GLOBAL_DEFINES += \
 	IMX_SAI_PERMISSIVE=1 \
 	IMX_SAI_WARMUP_NR_PERIODS=1 \
-	IMX_SAI_WARMUP_NR_PERIODS_FRAC=4
+	IMX_SAI_WARMUP_NR_PERIODS_FRAC=4 \
+	AF_LK_LOGLEVEL=6 \
 
 include project/virtual/test.mk
 

--- a/project/pae-imx8mn-dts.mk
+++ b/project/pae-imx8mn-dts.mk
@@ -11,6 +11,7 @@ MODULES += \
         dev/ivshmem/services/console \
         dev/ivshmem/services/binary \
         dev/ivshmem/services/rpc \
+		dev/ivshmem/services/serial
 
 #GLOBAL_DEFINES += \
 

--- a/target/imx8mn/dts/imx8mn-evk.dts
+++ b/target/imx8mn/dts/imx8mn-evk.dts
@@ -68,9 +68,18 @@
         status = "disabled";
     };
 
-    rpmsg-serial0 {
+    tty_lk_transport {
         compatible = "ivshm_serial";
+        id_str = "lk_transport";
         id = <0x400>;
+        size = <0x200>;
+        status = "ok";
+    };
+
+    tty_lk_dsp {
+        compatible = "ivshm_serial";
+        id_str = "lk_dsp";
+        id = <0x401>;
         size = <0x200>;
         status = "ok";
     };

--- a/target/imx8mn/dts/imx8mn-evk.dts
+++ b/target/imx8mn/dts/imx8mn-evk.dts
@@ -68,6 +68,13 @@
         status = "disabled";
     };
 
+    rpmsg-serial0 {
+        compatible = "ivshm_serial";
+        id = <0x400>;
+        size = <0x200>;
+        status = "ok";
+    };
+
     wm8524 {
         compatible = "dac_wm8524";
         bus-id = < 1 >;


### PR DESCRIPTION
This PR adds the shared-memory "serial" pipe driver which is based on the similar console and binary drivers.  I'm _not_ fully happy with the name "serial" but it kinda made sense to me since these will show up like serial ports (eg /dev/tty_lk_transport) on the linux side.

The device tree changes to instantiate a "transport" and "dsp" instance are also included.

Since these are in the driver tree of LK, I've followed LK code style rather than ours.