### PR TITLE
Adv360 rpc transport

### DIFF
--- a/dev/ivshmem/services/serial/include/ivshmem-serial.h
+++ b/dev/ivshmem/services/serial/include/ivshmem-serial.h
@@ -3,6 +3,7 @@
 #define __IVSHMEM_SERIAL_H
 #include <stddef.h>
 #include <compiler.h>
+#include <err.h>
 
 __BEGIN_CDECLS
 

--- a/dev/ivshmem/services/serial/ivshmem-serial.c
+++ b/dev/ivshmem/services/serial/ivshmem-serial.c
@@ -16,7 +16,6 @@
 #include <lib/console.h>
 #include <dev/driver.h>
 #include <dev/ivshm.h>
-#include <err.h>
 
 #include <string.h>
 #include <stdlib.h>

--- a/dev/ivshmem/services/serial/ivshmem-serial.c
+++ b/dev/ivshmem/services/serial/ivshmem-serial.c
@@ -247,10 +247,11 @@ static inline void write_chars(struct ivshm_serial_service *service, char *buf, 
 static ssize_t ivshm_serial_consume(struct ivshm_endpoint *ep, struct ivshm_pkt *pkt)
 {
     char *payload = (char *) &pkt->payload;
-    size_t len = ivshm_pkt_get_payload_length(pkt);
-    unsigned id = IVSHM_EP_GET_ID(ep->id);
 
-    LTRACEF("recvd %lu bytes on ept %d, content: '%s' \n", len, id, payload);
+    // apparently, the ivshmem endpoint appends a null char, so we need to drop it
+    size_t len = ivshm_pkt_get_payload_length(pkt) - 1;
+    
+    unsigned id = IVSHM_EP_GET_ID(ep->id);
 
     // get the service struct and either buffer or send it to callback
     struct ivshm_serial_service *service = _get_service(id);


### PR DESCRIPTION
Small fix needed for eRPC to work.  The ivshmem_endpoint layer in LK (which the ivshmem_serial depends on ) appends a null char to every chunk of bytes that come in.  Here we just drop that extra char rather than copying it down the line.